### PR TITLE
Masking for TFM DAS

### DIFF
--- a/src/arim/im/tfm.py
+++ b/src/arim/im/tfm.py
@@ -439,7 +439,7 @@ def contact_tfm(
     return TfmResult(res, grid)
 
 
-def tfm_for_view(frame, grid, view, amplitudes=None, **kwargs_delay_and_sum):
+def tfm_for_view(frame, grid, view, amplitudes=None, mask=None,**kwargs_delay_and_sum):
     """
     TFM for a view
 
@@ -474,7 +474,13 @@ def tfm_for_view(frame, grid, view, amplitudes=None, **kwargs_delay_and_sum):
     focal_law = FocalLaw(lookup_times_tx, lookup_times_rx, amplitudes)
 
     res = das.delay_and_sum(frame, focal_law, **kwargs_delay_and_sum)
-    res = res.reshape(grid.shape)
+    if np.prod(grid.shape) == res.size:
+        res = res.reshape(grid.shape)
+    else:
+        res_all = np.zeros([grid.size,],dtype=res.dtype)
+        #indeces = np.argwhere()[:,0]
+        res_all[mask.flatten()==True] = res
+        res = res_all.reshape(grid.shape)
     return TfmResult(res, grid)
 
 

--- a/src/arim/im/tfm.py
+++ b/src/arim/im/tfm.py
@@ -478,7 +478,6 @@ def tfm_for_view(frame, grid, view, amplitudes=None, mask=None,**kwargs_delay_an
         res = res.reshape(grid.shape)
     else:
         res_all = np.zeros([grid.size,],dtype=res.dtype)
-        #indeces = np.argwhere()[:,0]
         res_all[mask.flatten()==True] = res
         res = res_all.reshape(grid.shape)
     return TfmResult(res, grid)


### PR DESCRIPTION
Added a mask to tfm_for_view to allow for reconstruction over a mask. This assumes views/focal laws have been created with a subset of the grid.